### PR TITLE
Replace gen_range(a, b) with gen_range(a..b)

### DIFF
--- a/indicatif-tokio/src/bin/multi.rs
+++ b/indicatif-tokio/src/bin/multi.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), util::BoxError> {
     let tasks = futures::stream::repeat(())
         .map(|_| tokio::time::interval(
             tokio::time::Duration::from_millis(
-                rng.gen_range(task_delay_millis.0,
+                rng.gen_range(task_delay_millis.0..
                 task_delay_millis.1
             )
         ))


### PR DESCRIPTION
In [rand 0.8.0](https://github.com/rust-random/rand/blob/HEAD/CHANGELOG.md#080---2020-12-18), gen_range(a, b) was replaced with gen_range(a..b).

Should I also pin the dependency to minor version 0.8 (`^0.8`)? 